### PR TITLE
Remove redundant paths

### DIFF
--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -102,7 +102,7 @@ You can open the Rmd file as normal.
 
 ## Transcriptome indices for non-human organisms
 
-During the introduction to bulk RNA-seq module, we use human data.
+During the introduction to bulk RNA-seq module, we used human data.
 We include transcriptome indices for human in `training-modules/RNA-seq/index/`.
 If you have non-human RNA-seq data you would like to quantify, we have prepared indices for select non-human organisms relevant to the study of childhood cancer.
 
@@ -110,30 +110,30 @@ If you have RNA-seq data for an organism that is not listed, please post in the 
 
 ### _Mus musculus_
 
-Ensembl GRCm38 (mm10)
+Ensembl GRCm38 (mm10) v95
 
 | File description | File use | File path |
 |------------------|----------|-----------|
-| Mouse Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/short/short` |
-| Mouse Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/long/long` |
+| Mouse Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/short` |
+| Mouse Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/long` |
 | Mouse transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Mus_musculus.GRCm38.95_tx2gene.tsv` |
 
 ### _Danio rerio_
 
-Ensembl GRCz11
+Ensembl GRCz11 v95
 
 | File description | File use | File path |
 |------------------|----------|-----------|
-| Zebrafish Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/short/short` |
-| Zebrafish Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/long/long` |
+| Zebrafish Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/short` |
+| Zebrafish Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/long` |
 | Zebrafish transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Danio_rerio.GRCz11.95_tx2gene.tsv` |
 
 ### _Canis lupus familiaris_
 
-Ensembl CanFam3.1
+Ensembl CanFam3.1 v95
 
 | File description | File use | File path |
 |------------------|----------|-----------|
-| Dog Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/short/short` |
-| Dog Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/long/long` |
+| Dog Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/short` |
+| Dog Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/long` |
 | Dog transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Canis_familiaris.CanFam3.1.95_tx2gene.tsv` |

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -116,7 +116,6 @@ Ensembl GRCm38 (mm10) v95
 |------------------|----------|-----------|
 | Mouse Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/short` |
 | Mouse Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/mm10_cdna/salmon_index/long` |
-| Mouse transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Mus_musculus.GRCm38.95_tx2gene.tsv` |
 
 ### _Danio rerio_
 
@@ -126,7 +125,6 @@ Ensembl GRCz11 v95
 |------------------|----------|-----------|
 | Zebrafish Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/short` |
 | Zebrafish Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/z11_cdna/salmon_index/long` |
-| Zebrafish transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Danio_rerio.GRCz11.95_tx2gene.tsv` |
 
 ### _Canis lupus familiaris_
 
@@ -136,4 +134,3 @@ Ensembl CanFam3.1 v95
 |------------------|----------|-----------|
 | Dog Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/short` |
 | Dog Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/CanFam3p1_cdna/salmon_index/long` |
-| Dog transcript to gene mapping tsv (`tx2gene`) | TSV for `tx2gene` argument to `tximport::tximport()` | `~/shared-data/reference/tx2gene/Canis_familiaris.CanFam3.1.95_tx2gene.tsv` |

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -107,7 +107,7 @@ During the introduction to bulk RNA-seq module, we used human data and included 
 
 If you have non-human RNA-seq data you would like to quantify, or want to experiment with slightly different index parameters, we have prepared indices for select organisms relevant to the study of childhood cancer.
 Note that for most of these, you will need to perform a few extra steps to read in the quantification data with `tximeta` after performing quantification.
-Please see the notebook [`RNASeq/00c-tximeta_other_species.Rmd`](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/00c-tximeta_other_species.Rmd) for details on how to set this up. 
+Please see the notebook [`RNA-seq/00c-tximeta_other_species.Rmd`](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/00c-tximeta_other_species.Rmd) for details on how to set this up. 
 
 If you have RNA-seq data for an organism that is not listed, please post in the training-specific Slack channel and let your instructors know.
 

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -102,11 +102,21 @@ You can open the Rmd file as normal.
 
 ## Transcriptome indices for non-human organisms
 
-During the introduction to bulk RNA-seq module, we used human data.
-We include transcriptome indices for human in `training-modules/RNA-seq/index/`.
-If you have non-human RNA-seq data you would like to quantify, we have prepared indices for select non-human organisms relevant to the study of childhood cancer.
+During the introduction to bulk RNA-seq module, we used human data and included a transcriptome index for human in `training-modules/RNA-seq/index/`.
 
+If you have non-human RNA-seq data you would like to quantify, or want to experiment with slightly different index parameters, we have prepared indices for select organisms relevant to the study of childhood cancer.
 If you have RNA-seq data for an organism that is not listed, please post in the training-specific Slack channel and let your instructors know.
+
+### _Homo sapiens_
+
+Ensembl GRCh38 (hg38) v95
+
+| File description | File use | File path |
+|------------------|----------|-----------|
+| Human Salmon index `-k 23` | Salmon index for use with `salmon quant`; appropriate for reads shorter than 75bp or for increased sensitivity with `--validateMappings` ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/hg38_cdna/salmon_index/short` |
+| Human Salmon index `-k 31` | Salmon index for use with `salmon quant`; appropriate for reads 75bp or longer ([docs](https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcriptome-indices-mapping-based-mode)) | `~/shared-data/reference/refgenie/hg38_cdna/salmon_index/long` |
+
+
 
 ### _Mus musculus_
 

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -17,6 +17,7 @@ On this page, we've assembled some resources you may find helpful during these s
   - [RNA-seq data](#rna-seq-data)
     - [Getting a copy of the SRAdb example notebook in your home directory on RStudio Server](#getting-a-copy-of-the-sradb-example-notebook-in-your-home-directory-on-rstudio-server)
 - [Transcriptome indices for non-human organisms](#transcriptome-indices-for-non-human-organisms)
+  - [_Homo sapiens_](#homo-sapiens)
   - [_Mus musculus_](#mus-musculus)
   - [_Danio rerio_](#danio-rerio)
   - [_Canis lupus familiaris_](#canis-lupus-familiaris)
@@ -105,6 +106,9 @@ You can open the Rmd file as normal.
 During the introduction to bulk RNA-seq module, we used human data and included a transcriptome index for human in `training-modules/RNA-seq/index/`.
 
 If you have non-human RNA-seq data you would like to quantify, or want to experiment with slightly different index parameters, we have prepared indices for select organisms relevant to the study of childhood cancer.
+Note that for most of these, you will need to perform a few extra steps to read in the quantification data with `tximeta` after performing quantification.
+Please see the notebook [`RNASeq/00c-tximeta_other_species.Rmd`](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/00c-tximeta_other_species.Rmd) for details on how to set this up. 
+
 If you have RNA-seq data for an organism that is not listed, please post in the training-specific Slack channel and let your instructors know.
 
 ### _Homo sapiens_


### PR DESCRIPTION
I noticed that we had the ugly `short/short` links in here, which should be gone now, or at the least irrelevant.

I also added a note of Ensembl versions.

Are we linking both human indices? I don't think we currently do, but we want to, we will need to add that link in `training-modules/scripts/link-data.sh`