### PR TITLE
Update `workshop/workshop-materials.md`

### DIFF
--- a/workshop/workshop-materials.md
+++ b/workshop/workshop-materials.md
@@ -21,6 +21,7 @@ In this training workshop, we will be using the following modules:
 
 - [Intro to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/intro-to-R-tidyverse)
 - [RNA-Seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/RNA-seq)
+- [Pathway Analysis](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/pathway-analysis)
 
 
 The layout of the `training-modules` folders follow a common general structure.


### PR DESCRIPTION
This PR closes #13.

The purpose of this PR is to update the `workshop/workshop-materials.md` doc to reflect the content of this workshop by adding the URL to the pathway analysis folder.

Now that the module structure diagram has been updated (merged PR AlexsLemonade/training-modules#444), this document should be all set for the upcoming training once this PR is merged, based on https://github.com/AlexsLemonade/2021-march-training/issues/13#issue-805630508. See the [2021-march-training website](https://alexslemonade.github.io/2021-march-training/workshop/workshop-materials.html) to confirm this.