### PR TITLE
Add the 2021-march release tag

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -10,7 +10,7 @@ start_date: 2021-03-22
 end_date: 2021-03-26
 # Specific release in AlexsLemonade/training-modules
 # We use master to make development easier
-release_tag: master
+release_tag:  2021-march
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
 docker_repo: DOCKER-REPOSITORY


### PR DESCRIPTION
That's it, just changes the release tag in the config file.

I have confirmed locally that the links work (in general... I did not test every link!).

Closes #8

