### PR TITLE
Add required software header page to `_config.yaml`

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -35,6 +35,7 @@ header_pages:
   # as described at https://github.com/AlexsLemonade/training-specific-template#customizing-the-new-repository-for-an-individual-training-workshop
   - workshop/SCHEDULE.md
   - workshop/workshop-structure.md
+  - workshop/software-setup.md
   - workshop/workshop-materials.md
   - workshop/resources-for-consultation-sessions.md
   - workshop/posting-errors-guidelines.md

--- a/workshop/software-setup.md
+++ b/workshop/software-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Software Setup
+nav_title: Required Software
 ---
 
 ## Required software


### PR DESCRIPTION
This PR closes #5.

Here I am adding the `software-setup.md` file to the header (using `header_pages:`) in `_config.yaml`.
I also updated the `nav_title:` to be `Required Software` as it was noted that this is what we did in the past https://github.com/AlexsLemonade/2021-march-training/issues/5#issuecomment-801104684.

All other header pages were updated in merged PR #19 as noted in https://github.com/AlexsLemonade/2021-march-training/issues/5#issuecomment-799485020.